### PR TITLE
Fixed conda environmant name

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ conda env create -f environment.yaml
 ## Test run
 
 ```
-conda activate flex_benchmark_env
+conda activate flex_benchmarks_env
 snakemake -p -s Snakefile.py -j 2 --configfile settings_test.yaml 
 ```
 


### PR DESCRIPTION
Conda automatically creates an environment called "flex_benchmarks_env". In the README the user is instructed to activate "flex_benchmark_env". I just added the "s", minor change. Might perhaps help some potential users though.

If you prefer it, you can also implement the tiny change yourself, and ignore this pull request. Thought it would be easiest like this.